### PR TITLE
Fix: review from golangCI

### DIFF
--- a/cli/aozora-bunko/facade/lookup-book.go
+++ b/cli/aozora-bunko/facade/lookup-book.go
@@ -30,7 +30,7 @@ var contentMap = map[ContentType]string{
 
 func NewContent(s string) ContentType {
 	for k, v := range contentMap {
-		if strings.ToLower(s) == strings.ToLower(v) {
+		if strings.EqualFold(s, v) {
 			return k
 		}
 	}


### PR DESCRIPTION
Should use strings.EqualFold(a, b) instead of strings.ToLower(a) == strings.ToLower(b)